### PR TITLE
Add GET /api/v1/tenants endpoint for superadmins

### DIFF
--- a/src/features/tenants/tenants.routes.ts
+++ b/src/features/tenants/tenants.routes.ts
@@ -1,13 +1,45 @@
 import { Router } from 'express';
-import { createTenant, getTenant, updateTenant, deleteTenant } from './tenants.controller.js';
+import { createTenant, getTenant, updateTenant, deleteTenant, getAllTenants } from './tenants.controller.js';
 import { wrapAsyncHandler } from '../../utils/response.js';
 import { getCloudIntegrationsRouter } from '../cloud-integrations/cloudIntegrations.routes.js';
+import { requireSuperAdminRole } from '../../middleware/roles.js';
 
 export function getTenantRouter(): Router {
   const router = Router();
 
   // JWT authentication is already applied globally in app.ts
   // No need to apply it again here
+
+  /**
+   * @swagger
+   * /api/v1/tenants:
+   *   get:
+   *     summary: List all tenants (superadmin only)
+   *     description: Retrieves a list of all tenants in the system. Only accessible to superadmins.
+   *     tags: [Tenants]
+   *     security:
+   *       - bearerAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: includeArchived
+   *         schema:
+   *           type: boolean
+   *         description: Whether to include archived tenants in the results
+   *     responses:
+   *       200:
+   *         description: A list of tenants
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/TenantResponse'
+   *       401:
+   *         description: Unauthorized - JWT token is missing or invalid
+   *       403:
+   *         description: Forbidden - User is not a superadmin
+   */
+  router.get('/', requireSuperAdminRole(), wrapAsyncHandler(getAllTenants));
 
   // Create tenant
   router.post('/', wrapAsyncHandler(createTenant));

--- a/src/features/tenants/tenants.service.ts
+++ b/src/features/tenants/tenants.service.ts
@@ -139,4 +139,16 @@ export class TenantService {
     const superadmin = await getDB().collection('superadmins').findOne({ userId });
     return !!superadmin;
   }
+
+  async getAllTenants(options?: { includeArchived?: boolean }): Promise<Tenant[]> {
+    const filter: any = {};
+    
+    // By default, exclude archived tenants unless explicitly requested
+    if (!options?.includeArchived) {
+      filter.archived = { $ne: true };
+    }
+    
+    const tenants = await this.collection.find(filter).sort({ name: 1 }).toArray();
+    return tenants;
+  }
 }


### PR DESCRIPTION
## Description
This PR adds a new API endpoint for superadmins to list all tenants in the system.

## Features
- Adds GET /api/v1/tenants endpoint that returns a list of all tenants
- Endpoint is protected with the requireSuperAdminRole middleware
- Includes query parameter support for including archived tenants
- Implements proper response formatting using the tenantResponseSchema
- Adds comprehensive logging and audit trail

## Implementation Details
- Added getAllTenants method to TenantService
- Added getAllTenants controller function with proper error handling
- Updated tenant routes to include the new endpoint with superadmin middleware
- Added Swagger documentation for the new endpoint
- Implemented filtering to exclude archived tenants by default

## Security Considerations
- Endpoint is only accessible to superadmins
- Uses existing authentication and authorization middleware
- Follows MWAP security standards

## Testing
- Endpoint can be tested by making a GET request to /api/v1/tenants with a superadmin JWT token
- Optional query parameter ?includeArchived=true can be used to include archived tenants

## Related Issues
N/A